### PR TITLE
Threshold profiles

### DIFF
--- a/src/analysis/hsv_analyzer.py
+++ b/src/analysis/hsv_analyzer.py
@@ -36,6 +36,7 @@ class HSVAnalyzer:
         
         self.current_mask = None
         self.current_ellipse = None
+        self.inner_ellipse = None
         self.ellipse_score = None
         self.is_ellipse_enabled = True
         self.is_mask_frozen = False
@@ -52,7 +53,7 @@ class HSVAnalyzer:
         if self.is_ellipse_enabled:
             # Find ellipse and create mask only if  we didn't freeze the existing one
             if not self.is_mask_frozen:
-                self.current_mask, self.current_ellipse, self.ellipse_score = self.processor.mask_ellipse_contour(frame)
+                self.current_mask, self.current_ellipse, self.inner_ellipse, self.ellipse_score = self.processor.mask_ellipse_contour(frame)
         else:
             self.current_mask = None
             self.current_ellipse = None
@@ -79,7 +80,7 @@ class HSVAnalyzer:
         
         if self.is_ellipse_enabled and not self.is_mask_frozen:
             # Update mask
-            self.current_mask, self.current_ellipse, self.ellipse_score = self.processor.mask_ellipse_contour(frame)
+            self.current_mask, self.current_ellipse, self.inner_ellipse, self.ellipse_score = self.processor.mask_ellipse_contour(frame)
         
         # Calculate stats using the mask
         hsv_stats = self.processor.get_hsv_stats(hsv_frame, self.current_mask)

--- a/src/analysis/profile_manager.py
+++ b/src/analysis/profile_manager.py
@@ -1,0 +1,49 @@
+from dataclasses import dataclass
+from typing import Dict, Optional
+import csv
+import logging
+
+@dataclass
+class ThresholdProfile:
+    name: str
+    h_decay: Optional[float] = None
+    s_decay: Optional[float] = None
+    v_decay: Optional[float] = None
+    dh: Optional[float] = None
+    ds: Optional[float] = None
+    dv: Optional[float] = None
+    ddh: Optional[float] = None
+    dds: Optional[float] = None
+    ddv: Optional[float] = None
+
+class ProfileManager:
+    def __init__(self):
+        self.logger = logging.getLogger(__name__)
+        self.profiles: Dict[str, ThresholdProfile] = {}
+        
+    def load_profiles(self, csv_path: str):
+        """Load threshold profiles from CSV file"""
+        try:
+            with open(csv_path, 'r') as f:
+                reader = csv.DictReader(f)
+                for row in reader:
+                    # Convert empty strings to None, otherwise convert to float
+                    profile = ThresholdProfile(
+                        name=row['name'],
+                        **{key: float(val) if val.strip() else None 
+                           for key, val in row.items() 
+                           if key != 'name'}
+                    )
+                    self.profiles[profile.name] = profile
+                    self.logger.debug(f"Loaded profile: {profile}")
+            self.logger.info(f" Available threshold profiles: {', '.join(self.profiles.keys())}")
+        except Exception as e:
+            self.logger.error(f" Failed to load profiles: {str(e)}")
+            
+    def get_profile_names(self):
+        """Get list of available profile names"""
+        return list(self.profiles.keys())
+    
+    def get_profile(self, name: str) -> ThresholdProfile:
+        """Get profile by name"""
+        return self.profiles.get(name)

--- a/src/camera/processor.py
+++ b/src/camera/processor.py
@@ -7,7 +7,7 @@ class ImageProcessor:
     def __init__(self):
         self.prev_ellipse = None
         self.prev_mask = None
-        self.alpha = 0.4 # Smoothing factor for the ellipse mask
+        self.alpha = 0.6 # Smoothing factor for the ellipse mask
     
     @staticmethod
     def to_hsv(frame):

--- a/src/profiles.csv
+++ b/src/profiles.csv
@@ -1,0 +1,3 @@
+name,h_decay,s_decay,v_decay,dh,ds,dv,ddh,dds,ddv
+Graphene, 10, 15, 5, , , , , ,
+MoS2, 20, 50, -30, , , , , ,

--- a/src/web/server.py
+++ b/src/web/server.py
@@ -179,7 +179,7 @@ class WebServer:
             if self.analyzer.current_ellipse is not None:
                 # Draw the ellipse on the frame
                 cv2.ellipse(frame, self.analyzer.current_ellipse, (0, 255, 0), 2)
-
+                cv2.ellipse(frame, self.analyzer.inner_ellipse, (50, 255, 50), 1)
                 # Add the score to the frame
                 try:
                     text = f"Ellipse Score: {self.analyzer.ellipse_score:.2f}"
@@ -218,7 +218,7 @@ class WebServer:
                 toggle_ellipse = gr.Checkbox(True, label="Enable ellipsoid masking")
                 toggle_ellipse.change(fn=self.set_ellipse_fitting, inputs=[toggle_ellipse])
                 
-                history_size = gr.Number(60, label="History in seconds", precision=0, minimum=1, maximum=1200)
+                history_size = gr.Number(60, label="History in seconds", precision=0, minimum=0, maximum=1800)
                 history_size.change(fn=self.update_history_window, inputs=[history_size])
                 
                 manual_exposure = gr.Checkbox(False, label="Manual Exposure")


### PR DESCRIPTION
This PR adds a profile.csv file that can be sparsely filled with threshold values for each of the nine available data types (H, S, V, dH, dS, ddH, etc). During initialization, these profiles are loaded into a dropdown and are plotted as a dashed horizontal line if the corresponding value is also plotted. If all threshold conditions are met, a yellow alert modal pops up repeatedly and notifies the user of the event.

> [!IMPORTANT]
> The profile.csv contains dummy values for testing. They need to be changed for empirical testing.

The PR also adds an inner ellipse 90% of the original size. This inner ellipse is plotted alongside the outer ellipse and used for calculation, making the detection more robust by ignoring minor pixel shifts along the mask contour.

Lastly, this PR adds a log button that allows outputting all calculated values for the current timestamp, which is useful to take note of potential threshold values.